### PR TITLE
Change build option for JDK7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,9 @@ configurations {
 
 version = "0.1.1"
 
+sourceCompatibility = 1.7
+targetCompatibility = 1.7
+
 dependencies {
     compile  "org.embulk:embulk-core:0.7.4"
     provided "org.embulk:embulk-core:0.7.4"


### PR DESCRIPTION
Support JDK7 (avoid following error)

```
(LoadError) load error: embulk/input/mongodb -- java.lang.UnsupportedClassVersionError: org/embulk/input/mongodb/MongodbInputPlugin : Unsupported major.minor version 52.0
```