### PR TITLE
Refactor some codes

### DIFF
--- a/src/main/java/org/embulk/input/mongodb/MongodbInputPlugin.java
+++ b/src/main/java/org/embulk/input/mongodb/MongodbInputPlugin.java
@@ -100,6 +100,7 @@ public class MongodbInputPlugin
         PluginTask task = taskSource.loadTask(PluginTask.class);
         BufferAllocator allocator = task.getBufferAllocator();
         PageBuilder pageBuilder = new PageBuilder(allocator, schema, output);
+        JsonParser jsonParser = new JsonParser();
 
         MongoDatabase db = connect(task);
         MongoCollection<Document> collection = db.getCollection(task.getCollection());
@@ -119,7 +120,7 @@ public class MongodbInputPlugin
                 .batchSize(task.getBatchSize())
                 .iterator()) {
             while (cursor.hasNext()) {
-                fetch(cursor, pageBuilder);
+                fetch(cursor, pageBuilder, jsonParser);
             }
         }
 
@@ -140,8 +141,7 @@ public class MongodbInputPlugin
         return mongoClient.getDatabase(uri.getDatabase());
     }
 
-    private void fetch(MongoCursor<Document> cursor, PageBuilder pageBuilder) {
-	    final JsonParser jsonParser = new JsonParser();
+    private void fetch(MongoCursor<Document> cursor, PageBuilder pageBuilder, JsonParser jsonParser) {
         Document doc = cursor.next();
         List<Column> columns = pageBuilder.getSchema().getColumns();
         for (Column c : columns) {

--- a/src/main/java/org/embulk/input/mongodb/MongodbInputPlugin.java
+++ b/src/main/java/org/embulk/input/mongodb/MongodbInputPlugin.java
@@ -112,19 +112,15 @@ public class MongodbInputPlugin
         log.trace("projection: {}", projection);
         log.trace("sort: {}", sort);
 
-        MongoCursor<Document> cursor = collection
-                                        .find(query)
-                                        .projection(projection)
-                                        .sort(sort)
-                                        .batchSize(task.getBatchSize())
-                                        .iterator();
-
-        try {
+        try (MongoCursor<Document> cursor = collection
+                .find(query)
+                .projection(projection)
+                .sort(sort)
+                .batchSize(task.getBatchSize())
+                .iterator()) {
             while (cursor.hasNext()) {
                 fetch(cursor, pageBuilder);
             }
-        } finally {
-            cursor.close();
         }
 
         pageBuilder.finish();

--- a/src/main/java/org/embulk/input/mongodb/MongodbInputPlugin.java
+++ b/src/main/java/org/embulk/input/mongodb/MongodbInputPlugin.java
@@ -101,6 +101,7 @@ public class MongodbInputPlugin
         BufferAllocator allocator = task.getBufferAllocator();
         PageBuilder pageBuilder = new PageBuilder(allocator, schema, output);
         JsonParser jsonParser = new JsonParser();
+        List<Column> columns = pageBuilder.getSchema().getColumns();
 
         MongoDatabase db = connect(task);
         MongoCollection<Document> collection = db.getCollection(task.getCollection());
@@ -120,7 +121,7 @@ public class MongodbInputPlugin
                 .batchSize(task.getBatchSize())
                 .iterator()) {
             while (cursor.hasNext()) {
-                fetch(cursor, pageBuilder, jsonParser);
+                fetch(cursor, pageBuilder, jsonParser, columns);
             }
         }
 
@@ -141,9 +142,9 @@ public class MongodbInputPlugin
         return mongoClient.getDatabase(uri.getDatabase());
     }
 
-    private void fetch(MongoCursor<Document> cursor, PageBuilder pageBuilder, JsonParser jsonParser) {
+    private void fetch(MongoCursor<Document> cursor, PageBuilder pageBuilder,
+                       JsonParser jsonParser, List<Column> columns) {
         Document doc = cursor.next();
-        List<Column> columns = pageBuilder.getSchema().getColumns();
         for (Column c : columns) {
             Type t = c.getType();
             String key = normalize(c.getName());

--- a/src/main/java/org/embulk/input/mongodb/MongodbInputPlugin.java
+++ b/src/main/java/org/embulk/input/mongodb/MongodbInputPlugin.java
@@ -61,7 +61,7 @@ public class MongodbInputPlugin
         Integer getBatchSize();
 
         @ConfigInject
-        public BufferAllocator getBufferAllocator();
+        BufferAllocator getBufferAllocator();
     }
 
     private final Logger log = Exec.getLogger(MongodbInputPlugin.class);

--- a/src/main/java/org/embulk/input/mongodb/MongodbInputPlugin.java
+++ b/src/main/java/org/embulk/input/mongodb/MongodbInputPlugin.java
@@ -13,6 +13,7 @@ import org.bson.conversions.Bson;
 import org.embulk.config.Config;
 import org.embulk.config.ConfigDefault;
 import org.embulk.config.ConfigDiff;
+import org.embulk.config.ConfigException;
 import org.embulk.config.ConfigInject;
 import org.embulk.config.ConfigSource;
 import org.embulk.config.Task;
@@ -74,6 +75,12 @@ public class MongodbInputPlugin
             InputPlugin.Control control)
     {
         PluginTask task = config.loadConfig(PluginTask.class);
+        // Connect once to throw ConfigException in earlier stage of excecution
+        try {
+            connect(task);
+        } catch (UnknownHostException | MongoException ex) {
+            throw new ConfigException(ex);
+        }
         Schema schema = task.getFields().toSchema();
         return resume(task.dump(), schema, 1, control);
     }

--- a/src/main/java/org/embulk/input/mongodb/MongodbInputPlugin.java
+++ b/src/main/java/org/embulk/input/mongodb/MongodbInputPlugin.java
@@ -181,8 +181,8 @@ public class MongodbInputPlugin
                     break;
 
                 case "json":
-	                pageBuilder.setJson(c, jsonParser.parse(((Document) doc.get(key)).toJson()));
-					break;
+                    pageBuilder.setJson(c, jsonParser.parse(((Document) doc.get(key)).toJson()));
+                    break;
                 }
             }
         }

--- a/src/main/java/org/embulk/input/mongodb/MongodbInputPlugin.java
+++ b/src/main/java/org/embulk/input/mongodb/MongodbInputPlugin.java
@@ -129,8 +129,7 @@ public class MongodbInputPlugin
 
         pageBuilder.finish();
 
-        TaskReport report = Exec.newTaskReport();
-        return report;
+        return Exec.newTaskReport();
     }
 
     @Override


### PR DESCRIPTION
I added some fixes. This PR contains 8 commits but almost of them is very small fix.

Little big changes are following 2 commits.

1.  **Get collection count at connection() to throw Exception** (810e459)

    Current connect() method doesn't throw Exception even if connection was failed.
    So I added `db.getCollection(task.getCollection()).count();` to throw ConfigException when connection failure happened.


1. **Connect to Mongo DB at transaction() to throw ConfigException at earlier stage of execution** (85c75ce)
    In the usecase of Embulk, it is helpfull for user that plugin throw ConfigException in the earlier stage of execution if configuration has wrong setting.
    I added code at transaction() method that call connect() method so that plugin throw ConfigException if user specified wrong settings.