### PR TITLE
Add minimum limit to batch_size and changed not to allow null

### DIFF
--- a/src/main/java/org/embulk/input/mongodb/MongodbInputPlugin.java
+++ b/src/main/java/org/embulk/input/mongodb/MongodbInputPlugin.java
@@ -33,6 +33,7 @@ import org.embulk.spi.time.Timestamp;
 import org.embulk.spi.type.Type;
 import org.slf4j.Logger;
 
+import javax.validation.constraints.Min;
 import java.net.UnknownHostException;
 import java.util.List;
 
@@ -62,7 +63,8 @@ public class MongodbInputPlugin
 
         @Config("batch_size")
         @ConfigDefault("10000")
-        Integer getBatchSize();
+        @Min(1)
+        int getBatchSize();
 
         @ConfigInject
         BufferAllocator getBufferAllocator();


### PR DESCRIPTION
Current `batch_size` field is not validated appropriately.
I added `@Min(1)` annotation as same as [GzipFileEncoderPlugin](https://github.com/embulk/embulk/blob/master/embulk-standards/src/main/java/org/embulk/standards/GzipFileEncoderPlugin.java#L28) and used `int` instead of `Integer` to reject null.