### PR TITLE
Support id_field_name config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,21 @@ jdk:
   - oraclejdk7
   - openjdk7
 
+env:
+  global:
+    - MONGO_DATABASE=my_database
+    - MONGO_COLLECTION=my_collection
+    - MONGO_URI=mongodb://localhost:27017/my_database
+
 sudo: required
+
+before_cache:
+  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+cache:
+  directories:
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/
 
 # Work around fix for buffer overflow error on OpenJDK7
 # ref: https://github.com/travis-ci/travis-ci/issues/5227#issuecomment-165131913
@@ -29,17 +43,17 @@ install:
 before_script:
   - echo "Wait mongodb wakeup"
   - sleep 10
-  - mongoimport --db my_database --collection my_collection --type json --drop src/test/resources/my_collection.jsonl
-  - ./gradlew package
   - mkdir -p ./tmp
 
 script:
-  - embulk run -L . src/test/resources/basic.yml
-  - cat tmp/basic000.00.csv
-  - cmp tmp/basic000.00.csv src/test/resources/basic_expected.csv || exit 1
-  - embulk run -L . src/test/resources/full.yml
-  - cat tmp/full000.00.csv
-  - cmp tmp/full000.00.csv src/test/resources/full_expected.csv || exit 1
-  - embulk run -L . src/test/resources/id_field_name.yml
-  - cat tmp/id_field_name000.00.csv
-  - cmp tmp/id_field_name000.00.csv src/test/resources/id_field_name_expected.csv || exit 1
+  - mongoimport --db $MONGO_DATABASE --collection $MONGO_COLLECTION --type json --drop src/test/resources/my_collection.jsonl
+  - ./gradlew check
+  - ./gradlew package
+  - mongoimport --db $MONGO_DATABASE --collection $MONGO_COLLECTION --type json --drop src/test/resources/my_collection.jsonl
+  - |
+    for target in basic full id_field_name
+    do
+      embulk run -L . src/test/resources/${target}.yml
+      cat tmp/${target}000.00.csv
+      cmp tmp/${target}000.00.csv src/test/resources/${target}_expected.csv
+    done

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,3 +40,6 @@ script:
   - embulk run -L . src/test/resources/full.yml
   - cat tmp/full000.00.csv
   - cmp tmp/full000.00.csv src/test/resources/full_expected.csv || exit 1
+  - embulk run -L . src/test/resources/id_field_name.yml
+  - cat tmp/id_field_name000.00.csv
+  - cmp tmp/id_field_name000.00.csv src/test/resources/id_field_name_expected.csv || exit 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,9 +44,9 @@ before_script:
   - echo "Wait mongodb wakeup"
   - sleep 10
   - mkdir -p ./tmp
+  - date
 
 script:
-  - mongoimport --db $MONGO_DATABASE --collection $MONGO_COLLECTION --type json --drop src/test/resources/my_collection.jsonl
   - ./gradlew check
   - ./gradlew package
   - mongoimport --db $MONGO_DATABASE --collection $MONGO_COLLECTION --type json --drop src/test/resources/my_collection.jsonl

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ This plugin only works with embulk >= 0.8.8.
     ~~- double~~
     ~~- string~~
     ~~- timestamp~~
+- **id_field_name** (string, optional, default: "_id") Name of Object ID field name. Set if you want to change the default name `_id` 
 - **query**: a JSON document used for [querying](https://docs.mongodb.com/manual/tutorial/query-documents/) on the source collection. Documents are loaded from the colleciton if they match with this condition. (string, optional)
 - **projection**: A JSON document used for [projection](https://docs.mongodb.com/manual/reference/operator/projection/positional/) on query results. Fields in a document are used only if they match with this condition. (string, optional)
 - **sort**: ordering of results (string, optional)

--- a/src/main/java/org/embulk/input/mongodb/MongodbInputPlugin.java
+++ b/src/main/java/org/embulk/input/mongodb/MongodbInputPlugin.java
@@ -68,6 +68,10 @@ public class MongodbInputPlugin
         @ConfigDefault("\"{}\"")
         String getSort();
 
+        @Config("id_field_name")
+        @ConfigDefault("\"_id\"")
+        String getIdFieldName();
+
         @Config("batch_size")
         @ConfigDefault("10000")
         @Min(1)
@@ -144,7 +148,7 @@ public class MongodbInputPlugin
 
             CodecRegistry registry = CodecRegistries.fromRegistries(
                     MongoClient.getDefaultCodecRegistry(),
-                    CodecRegistries.fromCodecs(new ValueCodec(task.getStopOnInvalidRecord()))
+                    CodecRegistries.fromCodecs(new ValueCodec(task.getStopOnInvalidRecord(), task))
             );
             collection = db.getCollection(task.getCollection(), Value.class)
                     .withCodecRegistry(registry);

--- a/src/main/java/org/embulk/input/mongodb/ValueCodec.java
+++ b/src/main/java/org/embulk/input/mongodb/ValueCodec.java
@@ -50,6 +50,7 @@ public class ValueCodec implements Codec<Value>
         reader.readStartDocument();
         while (reader.readBsonType() != BsonType.END_OF_DOCUMENT) {
             String fieldName = reader.readName();
+            BsonType type = reader.getCurrentBsonType();
             fieldName = normalize(fieldName);
 
             try {
@@ -60,7 +61,6 @@ public class ValueCodec implements Codec<Value>
                 if (stopOnInvalidRecord) {
                     throw ex;
                 }
-                BsonType type = reader.getCurrentBsonType();
                 log.warn(String.format("Skipped document because field '%s' contains unsupported object type [%s]",
                         fieldName, type));
             }

--- a/src/main/java/org/embulk/input/mongodb/ValueCodec.java
+++ b/src/main/java/org/embulk/input/mongodb/ValueCodec.java
@@ -11,15 +11,6 @@ import org.embulk.spi.Exec;
 import org.msgpack.value.Value;
 import org.slf4j.Logger;
 
-import static org.msgpack.value.ValueFactory.newArray;
-import static org.msgpack.value.ValueFactory.newBinary;
-import static org.msgpack.value.ValueFactory.newBoolean;
-import static org.msgpack.value.ValueFactory.newFloat;
-import static org.msgpack.value.ValueFactory.newInteger;
-import static org.msgpack.value.ValueFactory.newMap;
-import static org.msgpack.value.ValueFactory.newNil;
-import static org.msgpack.value.ValueFactory.newString;
-
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
@@ -28,17 +19,21 @@ import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
 
+import static org.msgpack.value.ValueFactory.*;
+
 public class ValueCodec implements Codec<Value>
 {
     private final SimpleDateFormat formatter;
     private final Logger log = Exec.getLogger(MongodbInputPlugin.class);
     private final boolean stopOnInvalidRecord;
+    private final MongodbInputPlugin.PluginTask task;
 
-    public ValueCodec(boolean stopOnInvalidRecord)
+    public ValueCodec(boolean stopOnInvalidRecord, MongodbInputPlugin.PluginTask task)
     {
         this.formatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", java.util.Locale.ENGLISH);
         formatter.setTimeZone(TimeZone.getTimeZone("UTC"));
         this.stopOnInvalidRecord = stopOnInvalidRecord;
+        this.task = task;
     }
 
     @Override
@@ -53,14 +48,9 @@ public class ValueCodec implements Codec<Value>
         Map<Value, Value> kvs = new LinkedHashMap<>();
 
         reader.readStartDocument();
-        boolean isTopLevelNode = false;
         while (reader.readBsonType() != BsonType.END_OF_DOCUMENT) {
             String fieldName = reader.readName();
-            BsonType type = reader.getCurrentBsonType();
-            if (type == BsonType.OBJECT_ID) {
-                isTopLevelNode = true;
-            }
-            fieldName = normalize(fieldName, isTopLevelNode);
+            fieldName = normalize(fieldName);
 
             try {
                 kvs.put(newString(fieldName), readValue(reader, decoderContext));
@@ -70,6 +60,7 @@ public class ValueCodec implements Codec<Value>
                 if (stopOnInvalidRecord) {
                     throw ex;
                 }
+                BsonType type = reader.getCurrentBsonType();
                 log.warn(String.format("Skipped document because field '%s' contains unsupported object type [%s]",
                         fieldName, type));
             }
@@ -140,12 +131,10 @@ public class ValueCodec implements Codec<Value>
         return Value.class;
     }
 
-    private String normalize(String key, boolean isTopLevelNode)
+    private String normalize(String key)
     {
-        // 'id' is special alias key name of MongoDB ObjectId
-        // http://docs.mongodb.org/manual/reference/object-id/
-        if (key.equals("id") && isTopLevelNode) {
-            return "_id";
+        if (key.equals("_id")) {
+            return task.getIdFieldName();
         }
         return key;
     }

--- a/src/test/java/org/embulk/input/mongodb/TestMongodbInputPlugin.java
+++ b/src/test/java/org/embulk/input/mongodb/TestMongodbInputPlugin.java
@@ -193,7 +193,7 @@ public class TestMongodbInputPlugin
         PluginTask task = config.loadConfig(PluginTask.class);
         ValueCodec codec = new ValueCodec(true, task);
 
-        Method normalize = ValueCodec.class.getDeclaredMethod("normalize", String.class, boolean.class);
+        Method normalize = ValueCodec.class.getDeclaredMethod("normalize", String.class);
         normalize.setAccessible(true);
         assertEquals("_id", normalize.invoke(codec, "_id").toString());
         assertEquals("f1", normalize.invoke(codec, "f1").toString());
@@ -207,7 +207,7 @@ public class TestMongodbInputPlugin
         PluginTask task = config.loadConfig(PluginTask.class);
         ValueCodec codec = new ValueCodec(true, task);
 
-        Method normalize = ValueCodec.class.getDeclaredMethod("normalize", String.class, boolean.class);
+        Method normalize = ValueCodec.class.getDeclaredMethod("normalize", String.class);
         normalize.setAccessible(true);
         assertEquals("object_id", normalize.invoke(codec, "_id").toString());
         assertEquals("f1", normalize.invoke(codec, "f1").toString());
@@ -254,8 +254,7 @@ public class TestMongodbInputPlugin
     {
         return Exec.newConfigSource()
                 .set("uri", MONGO_URI)
-                .set("collection", MONGO_COLLECTION)
-                .set("last_path", "");
+                .set("collection", MONGO_COLLECTION);
     }
 
     private List<Document> createValidDocuments() throws Exception

--- a/src/test/java/org/embulk/input/mongodb/TestMongodbInputPlugin.java
+++ b/src/test/java/org/embulk/input/mongodb/TestMongodbInputPlugin.java
@@ -34,11 +34,13 @@ import org.junit.rules.ExpectedException;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
+import java.util.TimeZone;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
@@ -259,7 +261,7 @@ public class TestMongodbInputPlugin
 
     private List<Document> createValidDocuments() throws Exception
     {
-        SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.ENGLISH);
+        DateFormat format = getUTCDateFormat();
 
         List<Document> documents = new ArrayList<>();
         documents.add(
@@ -268,7 +270,7 @@ public class TestMongodbInputPlugin
                     .append("array_field", Arrays.asList(1, 2, 3))
                     .append("binary_field", new BsonBinary(("test").getBytes("UTF-8")))
                     .append("boolean_field", true)
-                    .append("datetime_field", format.parse("2015-01-27T19:23:49Z"))
+                    .append("datetime_field", format.parse("2015-01-27T10:23:49.000Z"))
                     .append("null_field", null)
                     .append("regex_field", new BsonRegularExpression(".+?"))
                     .append("javascript_field", new BsonJavaScript("var s = \"javascript\";"))
@@ -287,7 +289,7 @@ public class TestMongodbInputPlugin
 
         documents.add(new Document("document_field", new Document("k", "v")));
 
-        documents.add(new Document("document_field", new Document("k", format.parse("2015-02-03T08:13:45Z"))));
+        documents.add(new Document("document_field", new Document("k", format.parse("2015-02-02T23:13:45.000Z"))));
 
         return documents;
     }
@@ -305,6 +307,7 @@ public class TestMongodbInputPlugin
         assertEquals(5, records.size());
 
         ObjectMapper mapper = new ObjectMapper();
+        mapper.setDateFormat(getUTCDateFormat());
 
         {
             JsonNode node = mapper.readTree(records.get(0)[0].toString());
@@ -369,5 +372,11 @@ public class TestMongodbInputPlugin
         MongoDatabase db = (MongoDatabase) method.invoke(plugin, task);
         MongoCollection collection = db.getCollection(task.getCollection());
         collection.insertMany(documents);
+    }
+
+    private DateFormat getUTCDateFormat() {
+      DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", java.util.Locale.ENGLISH);
+      dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+      return dateFormat;
     }
 }

--- a/src/test/java/org/embulk/input/mongodb/TestMongodbInputPlugin.java
+++ b/src/test/java/org/embulk/input/mongodb/TestMongodbInputPlugin.java
@@ -190,17 +190,27 @@ public class TestMongodbInputPlugin
     @Test
     public void testNormalize() throws Exception
     {
-        ValueCodec codec = new ValueCodec(true);
+        PluginTask task = config.loadConfig(PluginTask.class);
+        ValueCodec codec = new ValueCodec(true, task);
 
         Method normalize = ValueCodec.class.getDeclaredMethod("normalize", String.class, boolean.class);
         normalize.setAccessible(true);
-        assertEquals("_id", normalize.invoke(codec, "id", true).toString());
-        assertEquals("_id", normalize.invoke(codec, "_id", true).toString());
-        assertEquals("f1", normalize.invoke(codec, "f1", true).toString());
+        assertEquals("_id", normalize.invoke(codec, "_id").toString());
+        assertEquals("f1", normalize.invoke(codec, "f1").toString());
+    }
 
-        assertEquals("id", normalize.invoke(codec, "id", false).toString());
-        assertEquals("_id", normalize.invoke(codec, "_id", false).toString());
-        assertEquals("f1", normalize.invoke(codec, "f1", false).toString());
+    @Test
+    public void testNormlizeWithIdFieldName() throws Exception
+    {
+        ConfigSource config = config().set("id_field_name", "object_id");
+
+        PluginTask task = config.loadConfig(PluginTask.class);
+        ValueCodec codec = new ValueCodec(true, task);
+
+        Method normalize = ValueCodec.class.getDeclaredMethod("normalize", String.class, boolean.class);
+        normalize.setAccessible(true);
+        assertEquals("object_id", normalize.invoke(codec, "_id").toString());
+        assertEquals("f1", normalize.invoke(codec, "f1").toString());
     }
 
     @Test

--- a/src/test/resources/id_field_name.yml
+++ b/src/test/resources/id_field_name.yml
@@ -1,0 +1,18 @@
+in:
+  type: mongodb
+  uri: mongodb://localhost:27017/my_database
+  collection: "my_collection"
+  json_column_name: "json"
+  query: '{ rank: { $gte: 3 } }'
+  sort: '{ rank: -1 }'
+  id_field_name: "object_id"
+  batch_size: 100
+out:
+  type: file
+  path_prefix: ./tmp/id_field_name
+  file_ext: csv
+  formatter:
+    type: csv
+    header_line: true
+    charset: UTF-8
+    newline: CRLF

--- a/src/test/resources/id_field_name_expected.csv
+++ b/src/test/resources/id_field_name_expected.csv
@@ -1,0 +1,8 @@
+json
+"{""object_id"":""55eae883689a08361045d652"",""name"":""obj9"",""rank"":9,""value"":9.9,""created_at"":""2015-09-06T10:05:18.786Z"",""embeded"":{""key"":""value9""}}"
+"{""object_id"":""55eae883689a08361045d651"",""name"":""obj8"",""rank"":8,""value"":8.8,""created_at"":""2015-09-06T10:05:28.786Z"",""embeded"":{""key"":""value8""}}"
+"{""object_id"":""55eae883689a08361045d650"",""name"":""obj7"",""rank"":7,""value"":7.7,""created_at"":""2015-09-06T10:05:38.786Z"",""embeded"":{""key"":""value7""}}"
+"{""object_id"":""55eae883689a08361045d64f"",""name"":""obj6"",""rank"":6,""value"":6.6,""created_at"":""2015-09-06T10:05:48.786Z"",""embeded"":{""key"":""value6""}}"
+"{""object_id"":""55eae883689a08361045d64e"",""name"":""obj5"",""rank"":5,""value"":5.5,""created_at"":""2015-09-06T10:05:58.786Z"",""embeded"":{""key"":""value5""}}"
+"{""object_id"":""55eae883689a08361045d64d"",""name"":""obj4"",""rank"":4,""value"":4.4,""created_at"":""2015-09-06T10:06:08.786Z"",""embeded"":{""key"":{""inner_key"":""value4""}}}"
+"{""object_id"":""55eae883689a08361045d64c"",""name"":""obj3"",""rank"":3,""value"":3.3,""created_at"":""2015-09-06T10:06:18.786Z"",""embeded"":{""key"":[""v3-1"",""v3-2""]}}"


### PR DESCRIPTION
Sometimes we want to rename MongoDB record ID field name `_id`, because column starting with `_` is a little bit tricky for other database user.

Most of case change `_id` to `id` is better, but record may have `id` field, so that it's better that user can define column name. To do this, I add `id_field_name` to configure name of record ID field like this:

```
in:
  type: mongodb
  uri: mongodb://myuser:mypassword@localhost:27017/my_database
  collection: "my_collection"
  id_field_name: "object_id"
```

output is

```
{"object_id":"55eae883689a08361045d652","name":"obj9","rank":9,"value":9.9,"created_at":"2015-09-06T10:05:18.786Z","embeded":{"key":"value9"}}
{"object_id":"55eae883689a08361045d651","name":"obj8","rank":8,"value":8.8,"created_at":"2015-09-06T10:05:28.786Z","embeded":{"key":"value8"}}
```

Default value is `_id`, so this change is backward compatible.