### PR TITLE
Support separated URI params

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This plugin only works with embulk >= 0.8.8.
   - use MongoDB connection string URI
     - **uri**: [MongoDB connection string URI](http://docs.mongodb.org/manual/reference/connection-string/) (e.g. 'mongodb://localhost:27017/mydb') (string, required)
   - use separated URI parameters
-    - **seeds**: list of hosts. seeds are pairs of host(string, required) and port(integer, optional, default: 27017)
+    - **hosts**: list of hosts. `hosts` are pairs of host(string, required) and port(integer, optional, default: 27017)
     - **username**: (string, optional)
     - **password**:  (string, optional)
     - **database**:  (string, required)
@@ -61,7 +61,7 @@ in:
 ```yaml
 in:
   type: mongodb
-  seeds:
+  hosts:
   - {host: localhost, port: 27017}
   - {host: example.com, port: 27017}
   username: myuser

--- a/README.md
+++ b/README.md
@@ -14,7 +14,16 @@ This plugin only works with embulk >= 0.8.8.
 
 ## Configuration
 
-- **uri**: [MongoDB connection string URI](http://docs.mongodb.org/manual/reference/connection-string/) (e.g. 'mongodb://localhost:27017/mydb') (string, required)
+- Connection parameters
+  One of them is required.
+  
+  - use MongoDB connection string URI
+    - **uri**: [MongoDB connection string URI](http://docs.mongodb.org/manual/reference/connection-string/) (e.g. 'mongodb://localhost:27017/mydb') (string, required)
+  - use separated URI parameters
+    - **seeds**: list of hosts. seeds are pairs of host(string, required) and port(integer, optional, default: 27017)
+    - **username**: (string, optional)
+    - **password**:  (string, optional)
+    - **database**:  (string, required)
 - **collection**: source collection name (string, required)
 - **fields**: **(deprecated)** ~~hash records that has the following two fields (array, required)~~
   ~~- name: Name of the column~~
@@ -38,10 +47,26 @@ This plugin only works with embulk >= 0.8.8.
 
 ### Exporting all objects
 
+#### Specify with MongoDB connection string URI.
+
 ```yaml
 in:
   type: mongodb
   uri: mongodb://myuser:mypassword@localhost:27017/my_database
+  collection: "my_collection"
+```
+
+#### Specify with separated URI parameters.
+
+```yaml
+in:
+  type: mongodb
+  seeds:
+  - {host: localhost, port: 27017}
+  - {host: example.com, port: 27017}
+  username: myuser
+  password: mypassword
+  database: my_database
   collection: "my_collection"
 ```
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This plugin only works with embulk >= 0.8.8.
     - **uri**: [MongoDB connection string URI](http://docs.mongodb.org/manual/reference/connection-string/) (e.g. 'mongodb://localhost:27017/mydb') (string, required)
   - use separated URI parameters
     - **hosts**: list of hosts. `hosts` are pairs of host(string, required) and port(integer, optional, default: 27017)
-    - **username**: (string, optional)
+    - **user**: (string, optional)
     - **password**:  (string, optional)
     - **database**:  (string, required)
 - **collection**: source collection name (string, required)
@@ -64,7 +64,7 @@ in:
   hosts:
   - {host: localhost, port: 27017}
   - {host: example.com, port: 27017}
-  username: myuser
+  user: myuser
   password: mypassword
   database: my_database
   collection: "my_collection"

--- a/src/main/java/org/embulk/input/mongodb/MongodbInputPlugin.java
+++ b/src/main/java/org/embulk/input/mongodb/MongodbInputPlugin.java
@@ -77,9 +77,9 @@ public class MongodbInputPlugin
         @ConfigDefault("null")
         Optional<List<HostTask>> getHosts();
 
-        @Config("username")
+        @Config("user")
         @ConfigDefault("null")
-        Optional<String> getUsername();
+        Optional<String> getUser();
 
         @Config("password")
         @ConfigDefault("null")
@@ -330,9 +330,9 @@ public class MongodbInputPlugin
             addresses.add(new ServerAddress(host.getHost(), host.getPort()));
         }
 
-        if (task.getUsername().isPresent()) {
+        if (task.getUser().isPresent()) {
             MongoCredential credential = MongoCredential.createCredential(
-                    task.getUsername().get(),
+                    task.getUser().get(),
                     task.getDatabase().get(),
                     task.getPassword().get().toCharArray()
             );

--- a/src/main/java/org/embulk/input/mongodb/MongodbInputPlugin.java
+++ b/src/main/java/org/embulk/input/mongodb/MongodbInputPlugin.java
@@ -54,7 +54,7 @@ import java.util.Map;
 public class MongodbInputPlugin
         implements InputPlugin
 {
-    public interface SeedAddressTask
+    public interface HostTask
             extends Task
     {
         @Config("host")
@@ -73,9 +73,9 @@ public class MongodbInputPlugin
         @ConfigDefault("null")
         Optional<String> getUri();
 
-        @Config("seeds")
+        @Config("hosts")
         @ConfigDefault("null")
-        Optional<List<SeedAddressTask>> getSeeds();
+        Optional<List<HostTask>> getHosts();
 
         @Config("username")
         @ConfigDefault("null")
@@ -296,8 +296,8 @@ public class MongodbInputPlugin
         MongoClient mongoClient;
         String database;
 
-        if (!task.getUri().isPresent() && !task.getSeeds().isPresent()) {
-            throw new ConfigException("'uri' or 'seeds' is required");
+        if (!task.getUri().isPresent() && !task.getHosts().isPresent()) {
+            throw new ConfigException("'uri' or 'hosts' is required");
         }
 
         if (task.getUri().isPresent()) {
@@ -318,15 +318,15 @@ public class MongodbInputPlugin
 
     private MongoClient createClientFromParams(PluginTask task)
     {
-        if (!task.getSeeds().isPresent()) {
-            throw new ConfigException("'seeds' option's value is required but empty");
+        if (!task.getHosts().isPresent()) {
+            throw new ConfigException("'hosts' option's value is required but empty");
         }
         if (!task.getDatabase().isPresent()) {
             throw new ConfigException("'database' option's value is required but empty");
         }
 
         List<ServerAddress> addresses = new ArrayList<>();
-        for (SeedAddressTask host : task.getSeeds().get()) {
+        for (HostTask host : task.getHosts().get()) {
             addresses.add(new ServerAddress(host.getHost(), host.getPort()));
         }
 

--- a/src/test/java/org/embulk/input/mongodb/TestMongodbInputPlugin.java
+++ b/src/test/java/org/embulk/input/mongodb/TestMongodbInputPlugin.java
@@ -208,7 +208,7 @@ public class TestMongodbInputPlugin
         Integer port = (host.split(":")[1] != null) ? Integer.valueOf(host.split(":")[1]) : 27017;
         ConfigSource config = Exec.newConfigSource()
                 .set("hosts", Arrays.asList(ImmutableMap.of("host", host.split(":")[0], "port", port)))
-                .set("username", uri.getUsername())
+                .set("user", uri.getUsername())
                 .set("password", uri.getPassword())
                 .set("database", uri.getDatabase())
                 .set("collection", MONGO_COLLECTION);

--- a/src/test/java/org/embulk/input/mongodb/TestMongodbInputPlugin.java
+++ b/src/test/java/org/embulk/input/mongodb/TestMongodbInputPlugin.java
@@ -207,7 +207,7 @@ public class TestMongodbInputPlugin
         String host = uri.getHosts().get(0);
         Integer port = (host.split(":")[1] != null) ? Integer.valueOf(host.split(":")[1]) : 27017;
         ConfigSource config = Exec.newConfigSource()
-                .set("seeds", Arrays.asList(ImmutableMap.of("host", host.split(":")[0], "port", port)))
+                .set("hosts", Arrays.asList(ImmutableMap.of("host", host.split(":")[0], "port", port)))
                 .set("username", uri.getUsername())
                 .set("password", uri.getPassword())
                 .set("database", uri.getDatabase())


### PR DESCRIPTION
I implemented following parameters to build URI.
* host
* port
* username
* password
* database

This pull-requests also support `uri` option as before, **so this PR has perfect backward compatibility**.

## Benefit

### Validation for each options

We can validate each options more detail.

Additionally, if user uses Embulk and something GUI interface together, this option should be more useful.

### Possible to adjust connection settings

We can adjust timeout, number of connection, connection lifetime and [other options](https://api.mongodb.com/java/3.2/com/mongodb/MongoClientOptions.Builder.html) if needed.
This is a part of code to create MongoClient in my PR.
```java
new MongoClient(addresses, Arrays.asList(credential));
```
This code can be rewriten to as follows.

```java
MongoClientOptions options = MongoClientOptions.builder()
                    .connectTimeout(600)
                    .connectionsPerHost(10)
                    .maxConnectionLifeTime(1000)
                    .build();
new MongoClient(addresses, Arrays.asList(credential), options);
```