### PR TITLE
Fix CI build on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
     - MONGO_URI=mongodb://localhost:27017/my_database
 
 sudo: required
+dist: precise
 
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock


### PR DESCRIPTION
A follow-up of #30 

Since September 1 2017, trusty become default environment
https://blog.travis-ci.com/2017-08-31-trusty-as-default-status
and CI settings depend on the environment.
However, since its support is going to end at April 1 2018, we should update CI settings soon.