### PR TITLE
Update mongo-java-driver to 3.2.2 to 3.6.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ targetCompatibility = 1.7
 dependencies {
     compile  "org.embulk:embulk-core:0.8.8"
     provided "org.embulk:embulk-core:0.8.8"
-    compile "org.mongodb:mongo-java-driver:3.2.2"
+    compile "org.mongodb:mongo-java-driver:3.6.1"
 
     testCompile "junit:junit:4.+"
     testCompile "org.embulk:embulk-core:0.8.8:tests"


### PR DESCRIPTION
Fix for https://github.com/hakobera/embulk-input-mongodb/issues/38
As written in http://mongodb.github.io/mongo-java-driver/3.6/upgrading/, 3.6.1 has backward compatibility for earlier version and works with both of Java7/8.

Additionally, 3.5+ supports Native POJO. We might be able to improve some parts that is using `com.mongodb.util.JSON.parse()` in the future.
http://mongodb.github.io/mongo-java-driver/3.6/whats-new/
  