### PR TITLE
Use BasicDBObject.parse(String) instead of deprecated JSON.parse(String)

### DIFF
--- a/src/main/java/org/embulk/input/mongodb/MongodbInputPlugin.java
+++ b/src/main/java/org/embulk/input/mongodb/MongodbInputPlugin.java
@@ -3,6 +3,7 @@ package org.embulk.input.mongodb;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Optional;
 import com.google.common.base.Throwables;
+import com.mongodb.BasicDBObject;
 import com.mongodb.MongoClient;
 import com.mongodb.MongoClientURI;
 import com.mongodb.MongoCredential;
@@ -11,7 +12,6 @@ import com.mongodb.ServerAddress;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoCursor;
 import com.mongodb.client.MongoDatabase;
-import com.mongodb.util.JSON;
 import com.mongodb.util.JSONParseException;
 import org.bson.codecs.configuration.CodecRegistries;
 import org.bson.codecs.configuration.CodecRegistry;
@@ -232,9 +232,9 @@ public class MongodbInputPlugin
             throw new ConfigException(ex);
         }
 
-        Bson query = (Bson) JSON.parse(task.getQuery());
-        Bson projection = (Bson) JSON.parse(task.getProjection());
-        Bson sort = (Bson) JSON.parse(task.getSort());
+        Bson query = BasicDBObject.parse(task.getQuery());
+        Bson projection = BasicDBObject.parse(task.getProjection());
+        Bson sort = BasicDBObject.parse(task.getSort());
 
         log.trace("query: {}", query);
         log.trace("projection: {}", projection);
@@ -422,7 +422,7 @@ public class MongodbInputPlugin
     private void validateJsonField(String name, String jsonString)
     {
         try {
-            JSON.parse(jsonString);
+            BasicDBObject.parse(jsonString);
         }
         catch (JSONParseException ex) {
             throw new ConfigException(String.format("Invalid JSON string was given for '%s' parameter. [%s]", name, jsonString));


### PR DESCRIPTION
Follow up for #39 
Use `com.mongodb.BasicDBObject.parse(String)` instead of `com.mongodb.util.JSON.parse(String)` since `JSON.parse()` was deprecated since mongo-java-driver 3.6.x.
http://mongodb.github.io/mongo-java-driver/3.6/javadoc/com/mongodb/util/JSON.html