### PR TITLE
Fix for #34 last_record generating logic output empty last_record when no record is imported

### DIFF
--- a/src/main/java/org/embulk/input/mongodb/MongodbInputPlugin.java
+++ b/src/main/java/org/embulk/input/mongodb/MongodbInputPlugin.java
@@ -163,9 +163,11 @@ public class MongodbInputPlugin
         }
 
         pageBuilder.finish();
+        return updateTaskReport(Exec.newTaskReport(), valueCodec);
+    }
 
-        TaskReport report = Exec.newTaskReport();
-
+    private TaskReport updateTaskReport(TaskReport report, ValueCodec valueCodec)
+    {
         if (valueCodec.getLastRecord() != null) {
             DataSource lastRecord = new DataSourceImpl(Exec.getInjector().getInstance(ModelManager.class));
             for (String k : valueCodec.getLastRecord().keySet()) {

--- a/src/main/java/org/embulk/input/mongodb/ValueCodec.java
+++ b/src/main/java/org/embulk/input/mongodb/ValueCodec.java
@@ -37,6 +37,7 @@ public class ValueCodec implements Codec<Value>
     private final PluginTask task;
     private final Optional<List<String>> incrementalField;
     private Map<String, Object> lastRecord;
+    private long processedRecordCount = 0;
     private Map<String, String> lastRecordType;
 
     public ValueCodec(boolean stopOnInvalidRecord, PluginTask task)
@@ -84,6 +85,7 @@ public class ValueCodec implements Codec<Value>
                 log.warn(String.format("Skipped document because field '%s' contains unsupported object type [%s]",
                         fieldName, type));
             }
+            this.processedRecordCount++;
         }
         reader.readEndDocument();
 
@@ -164,6 +166,11 @@ public class ValueCodec implements Codec<Value>
     public Map<String, Object> getLastRecord()
     {
         return this.lastRecord;
+    }
+
+    public Long getProcessedRecordCount()
+    {
+        return this.processedRecordCount;
     }
 
     public Map<String, String> getLastRecordType()


### PR DESCRIPTION
This PR is a bug fix for #34 

## What I changed
This plugin supports [incremental loading](https://github.com/hakobera/embulk-input-mongodb#incremental-loading) and output last_record after loading data.
```bash
$ embulk run config.yml -c diff.yml
```

* diff.yml
```yaml
in:
  last_record:
    _id: {$oid: 573ebe76e2064139e7f0c084}
    time: {$date: '2015-01-25T13:23:15.000Z'}
    account: 67899
out: {}
```

However, plugin will output empty last_record when plugin load 0 record.
This behavior is different from another plugins. So I changed implementation to make plugin behave same with other plugins.

## Difference of behavior

* diff.yml before execution
```yaml
in:
  last_record:
    _id: {$oid: 573ebe76e2064139e7f0c084}
    time: {$date: '2015-01-25T13:23:15.000Z'}
    account: 67899
out: {}
```
### Expected behavior (and with this PR)

```bash
$ embulk run config.yml -c diff.yml // 0 record was loaded
```
```yaml
in:
  last_record:
    _id: {$oid: 573ebe76e2064139e7f0c084}
    time: {$date: '2015-01-25T13:23:15.000Z'}
    account: 67899
out: {}
```

### Actual behavior (Without this PR)

```bash
$ embulk run config.yml -c diff.yml // 0 record was loaded
```
```yaml
in:
  last_record: {}
out: {}
```