### PR TITLE
Support "aggregation" query

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ targetCompatibility = 1.7
 dependencies {
     compile  "org.embulk:embulk-core:0.8.8"
     provided "org.embulk:embulk-core:0.8.8"
-    compile "org.mongodb:mongo-java-driver:3.6.1"
+    compile "org.mongodb:mongo-java-driver:3.8.1"
 
     testCompile "junit:junit:4.+"
     testCompile "org.embulk:embulk-core:0.8.8:tests"

--- a/src/main/java/org/embulk/input/mongodb/MongodbInputPlugin.java
+++ b/src/main/java/org/embulk/input/mongodb/MongodbInputPlugin.java
@@ -368,7 +368,7 @@ public class MongodbInputPlugin
     private void validateJsonField(String name, String jsonString)
     {
         try {
-            BasicDBObject.parse(jsonString);
+            Document.parse(jsonString);
         }
         catch (JsonParseException ex) {
             throw new ConfigException(String.format("Invalid JSON string was given for '%s' parameter. [%s]", name, jsonString));

--- a/src/main/java/org/embulk/input/mongodb/PluginTask.java
+++ b/src/main/java/org/embulk/input/mongodb/PluginTask.java
@@ -53,6 +53,10 @@ public interface PluginTask
     String getQuery();
     void setQuery(String query);
 
+    @Config("aggregation")
+    @ConfigDefault("null")
+    Optional<String> getAggregation();
+
     @Config("sort")
     @ConfigDefault("\"{}\"")
     String getSort();

--- a/src/test/java/org/embulk/input/mongodb/TestMongodbInputPlugin.java
+++ b/src/test/java/org/embulk/input/mongodb/TestMongodbInputPlugin.java
@@ -171,6 +171,19 @@ public class TestMongodbInputPlugin
         plugin.transaction(config, new Control());
     }
 
+    @Test(expected = ConfigException.class)
+    public void checkAggregationWithOtherOption()
+    {
+        ConfigSource config = Exec.newConfigSource()
+                .set("uri", MONGO_URI)
+                .set("collection", MONGO_COLLECTION)
+                .set("query", "{\"key\":\"valid_value\"}")
+                .set("aggregation", "{$match: { account: { $gt: 32864}}}")
+                .set("incremental_field", Optional.of(Arrays.asList("account")));
+
+        plugin.transaction(config, new Control());
+    }
+
     @Test
     public void testResume()
     {


### PR DESCRIPTION
This PR will fix #35 

## Problem of parsing Extended JSON
Currently, this plugin don't support aggregation feature of MongoDB.
It was not so difficult to support `aggregation` option since before, however, aggregation query sometimes become complex one and was not able to satisfy following restrictions.
```
{ $match: {
    "active_from":{"$lte":new Date() },
    $or: [
        { "active_until":{"$gt":new Date() }},
        { "active_until": null }
    ]
} },
{ $group: {_id: "$account_id", total: {$sum: 1} } }
```

The value of aggregation option must be...
1. Valid JSON string - We need to `JSON.parse()` to convert into Bson object
1. Valid Bson after `JSON.parse()`

I noticed Extended JSON was supported since [MongoDB Java Driver 3.5](http://mongodb.github.io/mongo-java-driver/3.5/whats-new/#improved-json-support).
`org.bson.Document.parse(json)` supports parsing Extended JSON and this will solve above problem.
http://mongodb.github.io/mongo-java-driver/3.8/bson/extended-json/#reading-json

```ruby
$ irb
irb(main):001:0> require 'JSON'
=> true
irb(main):002:0> JSON.parse("{ $match: {\"active_from\":{\"$lte\":new Date() },$or: [{ \"active_until\":{\"$gt\":new Date() }},{ \"active_until\": null }]} },{ $group: {_id: \"$account_id\", total: {$sum: 1} } }")
JSON::ParserError: 751: unexpected token at '{ $match: {"active_from":{"$lte":new Date() },$or: [{ "active_until":{"$gt":new Date() }},{ "active_until": null }]} },{ $group: {_id: "$account_id", total: {$sum: 1} } }'
```
```java
import org.bson.Document;

String json = "{ $match: {\"active_from\":{\"$lte\":new Date() },$or: [{ \"active_until\":{\"$gt\":new Date() }},{ \"active_until\": null }]} },{ $group: {_id: \"$account_id\", total: {$sum: 1} } }";
Document.parse(json); # no error happens
```

## Aggregation query support

To support aggregation query, I added new option `aggregation`.
This option can't be used with existing `sort`,  `limit`, `skip`, `query` options. incremental load as well.
If plugin use have a desire to use above feature, they need to include them in aggregation query.