### PR TITLE
Add "auth_method" and "auth_source" option to support explicit auth method and auth_source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 *~
+/db/
+/out/
 /pkg/
 /tmp/
 *.gemspec

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,14 +23,7 @@ cache:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
 
-# Work around fix for buffer overflow error on OpenJDK7
-# ref: https://github.com/travis-ci/travis-ci/issues/5227#issuecomment-165131913
 before_install:
-  - cat /etc/hosts # optionally check the content *before*
-  - sudo hostname "$(hostname | cut -c1-63)"
-  - sed -e "s/^\\(127\\.0\\.0\\.1.*\\)/\\1 $(hostname | cut -c1-63)/" /etc/hosts > /tmp/hosts
-  - sudo mv /tmp/hosts /etc/hosts
-  - cat /etc/hosts # optionally check the content *after*
   - sudo rm /usr/local/bin/docker-compose
   - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
   - chmod +x docker-compose

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,9 @@ services:
 
 env:
   global:
-    - MONGO_DATABASE=my_database
+    - MONGO_DATABASE=mydb
     - MONGO_COLLECTION=my_collection
-    - MONGO_URI=mongodb://localhost:27017/my_database
+    - MONGO_URI=mongodb://localhost:27017/mydb
     - DOCKER_COMPOSE_VERSION=1.22.0
 
 sudo: required
@@ -37,28 +37,21 @@ before_install:
   - sudo mv docker-compose /usr/local/bin
 
 install:
-  - sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10
-  - echo "deb http://repo.mongodb.org/apt/ubuntu "$(lsb_release -sc)"/mongodb-org/3.2 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.2.list
-  - sudo apt-get update
-  - sudo apt-get install -y --force-yes mongodb-org
-  - mongod -version
   - curl --create-dirs -o ~/.embulk/bin/embulk -L "https://dl.bintray.com/embulk/maven/embulk-0.8.8.jar"
   - chmod +x ~/.embulk/bin/embulk
   - export PATH="$HOME/.embulk/bin:$PATH"
   - embulk --version
 
 before_script:
-  - docker-compose up -d
-  - docker-compose ps
-  - echo "Wait mongodb wakeup"
-  - sleep 15
   - mkdir -p ./tmp
   - date
+  - docker-compose up -d
+  - docker-compose ps
 
 script:
   - ./gradlew check
   - ./gradlew package
-  - mongoimport --host 127.0.0.1 --db $MONGO_DATABASE --collection $MONGO_COLLECTION --type json --drop src/test/resources/my_collection.jsonl
+  - mongoimport --host 127.0.0.1 -u mongo_user -p dbpass --db $MONGO_DATABASE --collection $MONGO_COLLECTION --type json --drop src/test/resources/my_collection.jsonl
   - |
     for target in basic full id_field_name
     do

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,17 @@ language: java
 jdk:
   - oraclejdk8
 
+services:
+  - docker
+
 env:
   global:
     - MONGO_DATABASE=my_database
     - MONGO_COLLECTION=my_collection
     - MONGO_URI=mongodb://localhost:27017/my_database
+    - DOCKER_COMPOSE_VERSION=1.22.0
 
 sudo: required
-dist: precise
 
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
@@ -28,6 +31,10 @@ before_install:
   - sed -e "s/^\\(127\\.0\\.0\\.1.*\\)/\\1 $(hostname | cut -c1-63)/" /etc/hosts > /tmp/hosts
   - sudo mv /tmp/hosts /etc/hosts
   - cat /etc/hosts # optionally check the content *after*
+  - sudo rm /usr/local/bin/docker-compose
+  - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
+  - chmod +x docker-compose
+  - sudo mv docker-compose /usr/local/bin
 
 install:
   - sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10
@@ -41,6 +48,8 @@ install:
   - embulk --version
 
 before_script:
+  - docker-compose up -d
+  - docker-compose ps
   - echo "Wait mongodb wakeup"
   - sleep 15
   - mkdir -p ./tmp

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ This plugin only works with embulk >= 0.8.8.
     - **uri**: [MongoDB connection string URI](http://docs.mongodb.org/manual/reference/connection-string/) (e.g. 'mongodb://localhost:27017/mydb') (string, required)
   - use separated URI parameters
     - **hosts**: list of hosts. `hosts` are pairs of host(string, required) and port(integer, optional, default: 27017)
+    - **auth_method**: Auth method. One of `scram-sha-1`, `mongodb-cr`, `auto` (string, optional, default: null)
+    - **auth_source**: Auth source. The database name where the user is defined (string, optional, default: null)
     - **user**: (string, optional)
     - **password**:  (string, optional)
     - **database**:  (string, required)
@@ -45,6 +47,37 @@ This plugin only works with embulk >= 0.8.8.
 - **json_column_name**: column name used in outputs (string, optional, default: "record")
 
 ## Example
+
+### Authentication
+
+#### Use separated URI prameters
+
+```yaml
+in:
+  type: mongodb
+  hosts:
+  - {host: localhost, port:27017}
+  user:  myuser
+  password: mypassword
+  database: my_database
+  auth_method: scram-sha-1
+  auth_source: auth_db
+  collection: "my_collection
+```
+
+If you set `auth_method: auto`, The client will negotiate the best mechanism based on the version of the server that the client is authenticating to.
+
+If the server version is 3.0 or higher, the driver will authenticate using the SCRAM-SHA-1 mechanism.
+
+Otherwise, the driver will authenticate using the MONGODB_CR mechanism. 
+
+#### Use URI String
+
+```yaml
+in:
+  type: mongodb
+  uri: mongodb://myuser:mypassword@localhost:27017/my_database?authMechanism=SCRAM-SHA-1&authSource=another_database
+```
 
 ### Exporting all objects
 

--- a/README.md
+++ b/README.md
@@ -188,44 +188,21 @@ $ ./gradlew gem
 
 ## Test
 
-```
+Firstly install Docker and Docker compose then `docker-compose up -d`,
+so that an FTP server will be locally launched then you can run tests with `./gradlew test`.
+
+```sh
+$ docker-compose up -d
+Creating embulk-input-mongodb_server ... done
+Creating mongo-express               ... done
+Creating mongoClientTemp             ... done
+
+$ docker-compose ps
+           Name                          Command                 State                            Ports
+------------------------------------------------------------------------------------------------------------------------------
+embulk-input-mongodb_server   docker-entrypoint.sh mongod      Up           0.0.0.0:27017->27017/tcp, 0.0.0.0:27018->27018/tcp
+mongo-express                 tini -- /docker-entrypoint ...   Up           0.0.0.0:8081->8081/tcp
+mongoClientTemp               docker-entrypoint.sh mongo ...   Restarting
+
 $ ./gradlew test  # -t to watch change of files and rebuild continuously
-```
-
-To run unit tests, we need to configure the following environment variables.
-
-When environment variables are not set, skip almost test cases.
-
-```
-MONGO_URI
-MONGO_COLLECTION
-```
-
-If you're using Mac OS X El Capitan and GUI Applications(IDE), like as follows.
-```xml
-$ vi ~/Library/LaunchAgents/environment.plist
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-  <key>Label</key>
-  <string>my.startup</string>
-  <key>ProgramArguments</key>
-  <array>
-    <string>sh</string>
-    <string>-c</string>
-    <string>
-      launchctl setenv MONGO_URI mongodb://myuser:mypassword@localhost:27017/my_database
-      launchctl setenv MONGO_COLLECTION my_collection
-    </string>
-  </array>
-  <key>RunAtLoad</key>
-  <true/>
-</dict>
-</plist>
-
-$ launchctl load ~/Library/LaunchAgents/environment.plist
-$ launchctl getenv MONGO_URI //try to get value.
-
-Then start your applications.
 ```

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ $ ./gradlew gem
 ## Test
 
 Firstly install Docker and Docker compose then `docker-compose up -d`,
-so that an FTP server will be locally launched then you can run tests with `./gradlew test`.
+so that an MongoDB server will be locally launched then you can run tests with `./gradlew test`.
 
 ```sh
 $ docker-compose up -d

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,11 @@ services:
     image: mongo:3.6
     depends_on:
     - mongodb
-    command: mongo --host mongodb -u admin -p tiger admin --eval "db.getSiblingDB('mydb').createUser({user:'mongo_user', pwd:'dbpass', roles:[{role:'readWrite',db:'mydb'}]});"
+    # Sleep to wait MongoDB wake up on Travis CI
+    command: >
+      /bin/bash -c
+      "sleep 15 &&
+      mongo --host mongodb -u admin -p tiger admin --eval \"db.getSiblingDB('mydb').createUser({user:'mongo_user', pwd:'dbpass', roles:[{role:'readWrite',db:'mydb'}]});\""
 volumes:
   mongodb-data:
     driver: local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,40 @@
+version: '3.1'
+services:
+  mongodb:
+    container_name: embulk-input-mongodb_server
+    image: mongo:3.6
+    restart: always
+    ports:
+    - 27017:27017
+    - 27018:27018
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: admin
+      MONGO_INITDB_ROOT_PASSWORD: tiger
+    volumes:
+    - mongodb-data:/data/db
+    - mongodb-configdb:/data/configdb
+
+  mongo-express:
+    container_name: mongo-express
+    image: mongo-express
+    restart: always
+    ports:
+    - 8081:8081
+    depends_on:
+      - mongodb
+    environment:
+      ME_CONFIG_MONGODB_ADMINUSERNAME: admin
+      ME_CONFIG_MONGODB_ADMINPASSWORD: tiger
+      ME_CONFIG_MONGODB_SERVER: mongodb
+
+  mongoClientTemp:
+    container_name: mongoClientTemp
+    image: mongo:3.6
+    depends_on:
+    - mongodb
+    command: mongo --host mongodb -u admin -p tiger admin --eval "db.getSiblingDB('mydb').createUser({user:'mongo_user', pwd:'dbpass', roles:[{role:'readWrite',db:'mydb'}]});"
+volumes:
+  mongodb-data:
+    driver: local
+  mongodb-configdb:
+    driver: local

--- a/src/main/java/org/embulk/input/mongodb/AuthMethod.java
+++ b/src/main/java/org/embulk/input/mongodb/AuthMethod.java
@@ -1,0 +1,36 @@
+package org.embulk.input.mongodb;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import org.embulk.config.ConfigException;
+
+import java.util.Locale;
+
+public enum AuthMethod
+{
+    AUTO,
+    SCRAM_SHA_1,
+    MONGODB_CR;
+
+    @JsonValue
+    @Override
+    public String toString()
+    {
+        return name().toLowerCase(Locale.ENGLISH);
+    }
+
+    @JsonCreator
+    public static AuthMethod fromString(String value)
+    {
+        switch (value.replace("_", "-")) {
+            case "scram-sha-1":
+                return SCRAM_SHA_1;
+            case "mongodb-cr":
+                return MONGODB_CR;
+            case "auto":
+                return AUTO;
+            default:
+                throw new ConfigException(String.format("Unknown auth_method '%s'. Supported auth_method are scram-sha-1, mongodb-cr, auto", value));
+        }
+    }
+}

--- a/src/main/java/org/embulk/input/mongodb/PluginTask.java
+++ b/src/main/java/org/embulk/input/mongodb/PluginTask.java
@@ -25,6 +25,14 @@ public interface PluginTask
     @ConfigDefault("null")
     Optional<List<HostTask>> getHosts();
 
+    @Config("auth_method")
+    @ConfigDefault("null")
+    Optional<AuthMethod> getAuthMethod();
+
+    @Config("auth_source")
+    @ConfigDefault("null")
+    Optional<String> getAuthSource();
+
     @Config("user")
     @ConfigDefault("null")
     Optional<String> getUser();

--- a/src/test/java/org/embulk/input/mongodb/TestMongodbInputPlugin.java
+++ b/src/test/java/org/embulk/input/mongodb/TestMongodbInputPlugin.java
@@ -52,8 +52,8 @@ import static org.junit.Assert.assertThat;
 
 public class TestMongodbInputPlugin
 {
-    private final String MONGO_URI = "mongodb://mongo_user:dbpass@localhost:27017/mydb";
-    private final String MONGO_COLLECTION = "my_collection";
+    private final String mongoUri = "mongodb://mongo_user:dbpass@localhost:27017/mydb";
+    private final String mongoCollection = "my_collection";
 
     @Rule
     public EmbulkTestRuntime runtime = new EmbulkTestRuntime();
@@ -77,8 +77,8 @@ public class TestMongodbInputPlugin
     public void checkDefaultValues()
     {
         ConfigSource config = Exec.newConfigSource()
-                .set("uri", MONGO_URI)
-                .set("collection", MONGO_COLLECTION);
+                .set("uri", mongoUri)
+                .set("collection", mongoCollection);
 
         PluginTask task = config.loadConfig(PluginTask.class);
         assertEquals("{}", task.getQuery());
@@ -96,7 +96,7 @@ public class TestMongodbInputPlugin
     {
         ConfigSource config = Exec.newConfigSource()
                 .set("uri", null)
-                .set("collection", MONGO_COLLECTION);
+                .set("collection", mongoCollection);
 
         plugin.transaction(config, new Control());
     }
@@ -106,7 +106,7 @@ public class TestMongodbInputPlugin
     {
         ConfigSource config = Exec.newConfigSource()
                 .set("uri", "mongodb://mongouser:password@non-exists.example.com:23490/test")
-                .set("collection", MONGO_COLLECTION);
+                .set("collection", mongoCollection);
 
         plugin.transaction(config, new Control());
     }
@@ -115,7 +115,7 @@ public class TestMongodbInputPlugin
     public void checkDefaultValuesCollectionIsNull()
     {
         ConfigSource config = Exec.newConfigSource()
-                .set("uri", MONGO_URI)
+                .set("uri", mongoUri)
                 .set("collection", null);
 
         plugin.transaction(config, new Control());
@@ -125,8 +125,8 @@ public class TestMongodbInputPlugin
     public void checkSortCannotUseWithIncremental()
     {
         ConfigSource config = Exec.newConfigSource()
-                .set("uri", MONGO_URI)
-                .set("collection", MONGO_COLLECTION)
+                .set("uri", mongoUri)
+                .set("collection", mongoCollection)
                 .set("sort", "{ \"field1\": 1 }")
                 .set("incremental_field", Optional.of(Arrays.asList("account")));
 
@@ -137,8 +137,8 @@ public class TestMongodbInputPlugin
     public void checkSkipCannotUseWithIncremental()
     {
         ConfigSource config = Exec.newConfigSource()
-                .set("uri", MONGO_URI)
-                .set("collection", MONGO_COLLECTION)
+                .set("uri", mongoUri)
+                .set("collection", mongoCollection)
                 .set("skip", 10)
                 .set("incremental_field", Optional.of(Arrays.asList("account")));
 
@@ -149,8 +149,8 @@ public class TestMongodbInputPlugin
     public void checkInvalidQueryOption()
     {
         ConfigSource config = Exec.newConfigSource()
-                .set("uri", MONGO_URI)
-                .set("collection", MONGO_COLLECTION)
+                .set("uri", mongoUri)
+                .set("collection", mongoCollection)
                 .set("query", "{\"key\":invalid_value}")
                 .set("last_record", 0)
                 .set("incremental_field", Optional.of(Arrays.asList("account")));
@@ -162,8 +162,8 @@ public class TestMongodbInputPlugin
     public void checkAggregationWithOtherOption()
     {
         ConfigSource config = Exec.newConfigSource()
-                .set("uri", MONGO_URI)
-                .set("collection", MONGO_COLLECTION)
+                .set("uri", mongoUri)
+                .set("collection", mongoCollection)
                 .set("query", "{\"key\":\"valid_value\"}")
                 .set("aggregation", "{$match: { account: { $gt: 32864}}}")
                 .set("incremental_field", Optional.of(Arrays.asList("account")));
@@ -205,8 +205,8 @@ public class TestMongodbInputPlugin
     {
         PluginTask task = config.loadConfig(PluginTask.class);
 
-        dropCollection(task, MONGO_COLLECTION);
-        createCollection(task, MONGO_COLLECTION);
+        dropCollection(task, mongoCollection);
+        createCollection(task, mongoCollection);
         insertDocument(task, createValidDocuments());
 
         plugin.transaction(config, new Control());
@@ -217,13 +217,13 @@ public class TestMongodbInputPlugin
     public void testRunWithLimit() throws Exception
     {
         ConfigSource config = Exec.newConfigSource()
-                .set("uri", MONGO_URI)
-                .set("collection", MONGO_COLLECTION)
+                .set("uri", mongoUri)
+                .set("collection", mongoCollection)
                 .set("limit", 1);
         PluginTask task = config.loadConfig(PluginTask.class);
 
-        dropCollection(task, MONGO_COLLECTION);
-        createCollection(task, MONGO_COLLECTION);
+        dropCollection(task, mongoCollection);
+        createCollection(task, mongoCollection);
         insertDocument(task, createValidDocuments());
 
         plugin.transaction(config, new Control());
@@ -234,14 +234,14 @@ public class TestMongodbInputPlugin
     public void testRunWithLimitSkip() throws Exception
     {
         ConfigSource config = Exec.newConfigSource()
-                .set("uri", MONGO_URI)
-                .set("collection", MONGO_COLLECTION)
+                .set("uri", mongoUri)
+                .set("collection", mongoCollection)
                 .set("limit", 3)
                 .set("skip", 1);
         PluginTask task = config.loadConfig(PluginTask.class);
 
-        dropCollection(task, MONGO_COLLECTION);
-        createCollection(task, MONGO_COLLECTION);
+        dropCollection(task, mongoCollection);
+        createCollection(task, mongoCollection);
         insertDocument(task, createValidDocuments());
 
         plugin.transaction(config, new Control());
@@ -251,7 +251,7 @@ public class TestMongodbInputPlugin
     @Test
     public void testRunWithConnectionParams() throws Exception
     {
-        MongoClientURI uri = new MongoClientURI(MONGO_URI);
+        MongoClientURI uri = new MongoClientURI(mongoUri);
         String host = uri.getHosts().get(0);
         Integer port = (host.split(":")[1] != null) ? Integer.valueOf(host.split(":")[1]) : 27017;
         ConfigSource config = Exec.newConfigSource()
@@ -259,11 +259,11 @@ public class TestMongodbInputPlugin
                 .set("user", uri.getUsername())
                 .set("password", uri.getPassword())
                 .set("database", uri.getDatabase())
-                .set("collection", MONGO_COLLECTION);
+                .set("collection", mongoCollection);
         PluginTask task = config.loadConfig(PluginTask.class);
 
-        dropCollection(task, MONGO_COLLECTION);
-        createCollection(task, MONGO_COLLECTION);
+        dropCollection(task, mongoCollection);
+        createCollection(task, mongoCollection);
         insertDocument(task, createValidDocuments());
 
         plugin.transaction(config, new Control());
@@ -274,13 +274,13 @@ public class TestMongodbInputPlugin
     public void testRunWithIncrementalLoad() throws Exception
     {
         ConfigSource config = Exec.newConfigSource()
-                .set("uri", MONGO_URI)
-                .set("collection", MONGO_COLLECTION)
+                .set("uri", mongoUri)
+                .set("collection", mongoCollection)
                 .set("incremental_field", Optional.of(Arrays.asList("int32_field")));
         PluginTask task = config.loadConfig(PluginTask.class);
 
-        dropCollection(task, MONGO_COLLECTION);
-        createCollection(task, MONGO_COLLECTION);
+        dropCollection(task, mongoCollection);
+        createCollection(task, mongoCollection);
         insertDocument(task, createValidDocuments());
 
         ConfigDiff diff = plugin.transaction(config, new Control());
@@ -293,15 +293,15 @@ public class TestMongodbInputPlugin
     public void testRunWithLimitIncrementalLoad() throws Exception
     {
         ConfigSource config = Exec.newConfigSource()
-                .set("uri", MONGO_URI)
-                .set("collection", MONGO_COLLECTION)
+                .set("uri", mongoUri)
+                .set("collection", mongoCollection)
                 .set("id_field_name", "int32_field")
                 .set("incremental_field", Optional.of(Arrays.asList("int32_field", "double_field", "datetime_field", "boolean_field")))
                 .set("limit", 1);
         PluginTask task = config.loadConfig(PluginTask.class);
 
-        dropCollection(task, MONGO_COLLECTION);
-        createCollection(task, MONGO_COLLECTION);
+        dropCollection(task, mongoCollection);
+        createCollection(task, mongoCollection);
         insertDocument(task, createValidDocuments());
 
         ConfigDiff diff = plugin.transaction(config, new Control());
@@ -321,8 +321,8 @@ public class TestMongodbInputPlugin
         previousLastRecord.put("datetime_field", "{$date=2015-01-27T10:23:49.000Z}");
         previousLastRecord.put("boolean_field", true);
         ConfigSource config = Exec.newConfigSource()
-                .set("uri", MONGO_URI)
-                .set("collection", MONGO_COLLECTION)
+                .set("uri", mongoUri)
+                .set("collection", mongoCollection)
                 .set("id_field_name", "int32_field")
                 .set("query", "{\"double_field\":{\"$gte\": 1.23}}")
                 .set("incremental_field", Optional.of(Arrays.asList("int32_field", "datetime_field", "boolean_field")))
@@ -330,8 +330,8 @@ public class TestMongodbInputPlugin
 
         PluginTask task = config.loadConfig(PluginTask.class);
 
-        dropCollection(task, MONGO_COLLECTION);
-        createCollection(task, MONGO_COLLECTION);
+        dropCollection(task, mongoCollection);
+        createCollection(task, mongoCollection);
         insertDocument(task, createValidDocuments());
 
         ConfigDiff diff = plugin.transaction(config, new Control());
@@ -346,13 +346,13 @@ public class TestMongodbInputPlugin
     public void testRunWithIncrementalLoadUnsupportedType() throws Exception
     {
         ConfigSource config = Exec.newConfigSource()
-                .set("uri", MONGO_URI)
-                .set("collection", MONGO_COLLECTION)
+                .set("uri", mongoUri)
+                .set("collection", mongoCollection)
                 .set("incremental_field", Optional.of(Arrays.asList("document_field")));
         PluginTask task = config.loadConfig(PluginTask.class);
 
-        dropCollection(task, MONGO_COLLECTION);
-        createCollection(task, MONGO_COLLECTION);
+        dropCollection(task, mongoCollection);
+        createCollection(task, mongoCollection);
         insertDocument(task, createValidDocuments());
 
         plugin.transaction(config, new Control());
@@ -362,14 +362,14 @@ public class TestMongodbInputPlugin
     public void testRunWithUnsupportedType() throws Exception
     {
         ConfigSource config = Exec.newConfigSource()
-                .set("uri", MONGO_URI)
-                .set("collection", MONGO_COLLECTION)
+                .set("uri", mongoUri)
+                .set("collection", mongoCollection)
                 .set("stop_on_invalid_record", true);
 
         PluginTask task = config.loadConfig(PluginTask.class);
 
-        dropCollection(task, MONGO_COLLECTION);
-        createCollection(task, MONGO_COLLECTION);
+        dropCollection(task, mongoCollection);
+        createCollection(task, mongoCollection);
 
         List<Document> documents = new ArrayList<>();
         documents.add(
@@ -384,15 +384,15 @@ public class TestMongodbInputPlugin
     public void testRunWithAggregation() throws Exception
     {
         ConfigSource config = Exec.newConfigSource()
-                .set("uri", MONGO_URI)
-                .set("collection", MONGO_COLLECTION)
+                .set("uri", mongoUri)
+                .set("collection", mongoCollection)
                 .set("id_field_name", "int32_field")
                 .set("aggregation", "{ $match: {\"int32_field\":{\"$gte\":5 },} }");
 
         PluginTask task = config.loadConfig(PluginTask.class);
 
-        dropCollection(task, MONGO_COLLECTION);
-        createCollection(task, MONGO_COLLECTION);
+        dropCollection(task, mongoCollection);
+        createCollection(task, mongoCollection);
         insertDocument(task, createValidDocuments());
 
         plugin.transaction(config, new Control());
@@ -444,16 +444,16 @@ public class TestMongodbInputPlugin
     public void testBuildIncrementalCondition() throws Exception
     {
         PluginTask task = config().loadConfig(PluginTask.class);
-        dropCollection(task, MONGO_COLLECTION);
-        createCollection(task, MONGO_COLLECTION);
+        dropCollection(task, mongoCollection);
+        createCollection(task, mongoCollection);
         insertDocument(task, createValidDocuments());
 
         Method method = MongodbInputPlugin.class.getDeclaredMethod("buildIncrementalCondition", PluginTask.class);
         method.setAccessible(true);
 
         ConfigSource config = Exec.newConfigSource()
-                .set("uri", MONGO_URI)
-                .set("collection", MONGO_COLLECTION)
+                .set("uri", mongoUri)
+                .set("collection", mongoCollection)
                 .set("incremental_field", Optional.of(Arrays.asList("account")));
         task = config.loadConfig(PluginTask.class);
         Map<String, String> actual = (Map<String, String>) method.invoke(plugin, task);
@@ -471,8 +471,8 @@ public class TestMongodbInputPlugin
         innerRecord.put("$date", "2015-01-27T19:23:49Z");
         lastRecord.put("datetime_field", innerRecord);
         config = Exec.newConfigSource()
-                .set("uri", MONGO_URI)
-                .set("collection", MONGO_COLLECTION)
+                .set("uri", mongoUri)
+                .set("collection", mongoCollection)
                 .set("query", "{\"double_field\":{\"$gte\": 1.23}}")
                 .set("incremental_field", Optional.of(Arrays.asList("_id", "int32_field", "datetime_field")))
                 .set("last_record", Optional.of(lastRecord));
@@ -490,14 +490,14 @@ public class TestMongodbInputPlugin
         lastRecord.put("double_field", "0");
 
         ConfigSource config = Exec.newConfigSource()
-                .set("uri", MONGO_URI)
-                .set("collection", MONGO_COLLECTION)
+                .set("uri", mongoUri)
+                .set("collection", mongoCollection)
                 .set("query", "{\"double_field\":{\"$gte\": 1.23}}")
                 .set("incremental_field", Optional.of(Arrays.asList("double_field")))
                 .set("last_record", Optional.of(lastRecord));
         PluginTask task = config.loadConfig(PluginTask.class);
-        dropCollection(task, MONGO_COLLECTION);
-        createCollection(task, MONGO_COLLECTION);
+        dropCollection(task, mongoCollection);
+        createCollection(task, mongoCollection);
         insertDocument(task, createValidDocuments());
 
         Method method = MongodbInputPlugin.class.getDeclaredMethod("buildIncrementalCondition", PluginTask.class);
@@ -517,13 +517,13 @@ public class TestMongodbInputPlugin
         lastRecord.put("double_field", "0");
 
         ConfigSource config = Exec.newConfigSource()
-                .set("uri", MONGO_URI)
-                .set("collection", MONGO_COLLECTION)
+                .set("uri", mongoUri)
+                .set("collection", mongoCollection)
                 .set("incremental_field", Optional.of(Arrays.asList("invalid_field")))
                 .set("last_record", Optional.of(lastRecord));
         PluginTask task = config.loadConfig(PluginTask.class);
-        dropCollection(task, MONGO_COLLECTION);
-        createCollection(task, MONGO_COLLECTION);
+        dropCollection(task, mongoCollection);
+        createCollection(task, mongoCollection);
 
         Method method = MongodbInputPlugin.class.getDeclaredMethod("buildIncrementalCondition", PluginTask.class);
         method.setAccessible(true);
@@ -561,8 +561,8 @@ public class TestMongodbInputPlugin
     private ConfigSource config()
     {
         return Exec.newConfigSource()
-                .set("uri", MONGO_URI)
-                .set("collection", MONGO_COLLECTION);
+                .set("uri", mongoUri)
+                .set("collection", mongoCollection);
     }
 
     private List<Document> createValidDocuments() throws Exception

--- a/src/test/java/org/embulk/input/mongodb/TestMongodbInputPlugin.java
+++ b/src/test/java/org/embulk/input/mongodb/TestMongodbInputPlugin.java
@@ -31,7 +31,6 @@ import org.embulk.spi.TestPageBuilderReader.MockPageOutput;
 import org.embulk.spi.type.Types;
 import org.embulk.spi.util.Pages;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -53,8 +52,8 @@ import static org.junit.Assert.assertThat;
 
 public class TestMongodbInputPlugin
 {
-    private static String MONGO_URI;
-    private static String MONGO_COLLECTION;
+    private final String MONGO_URI = "mongodb://mongo_user:dbpass@localhost:27017/mydb";
+    private final String MONGO_COLLECTION = "my_collection";
 
     @Rule
     public EmbulkTestRuntime runtime = new EmbulkTestRuntime();
@@ -66,20 +65,8 @@ public class TestMongodbInputPlugin
     private MongodbInputPlugin plugin;
     private MockPageOutput output;
 
-    /*
-     * This test case requires environment variables
-     *   MONGO_URI
-     *   MONGO_COLLECTION
-     */
-    @BeforeClass
-    public static void initializeConstant()
-    {
-        MONGO_URI = System.getenv("MONGO_URI");
-        MONGO_COLLECTION = System.getenv("MONGO_COLLECTION");
-    }
-
     @Before
-    public void createResources() throws Exception
+    public void createResources()
     {
         config = config();
         plugin = new MongodbInputPlugin();

--- a/src/test/resources/basic.yml
+++ b/src/test/resources/basic.yml
@@ -1,6 +1,6 @@
 in:
   type: mongodb
-  uri: mongodb://localhost:27017/my_database
+  uri: mongodb://mongo_user:dbpass@localhost:27017/mydb
   collection: "my_collection"
   projection: '{ "_id": 0, "name": 1, "rank": 1 }'
   sort: '{ rank: 1 }'

--- a/src/test/resources/full.yml
+++ b/src/test/resources/full.yml
@@ -1,6 +1,6 @@
 in:
   type: mongodb
-  uri: mongodb://localhost:27017/my_database
+  uri: mongodb://mongo_user:dbpass@localhost:27017/mydb
   collection: "my_collection"
   json_column_name: "json"
   query: '{ rank: { $gte: 3 } }'

--- a/src/test/resources/id_field_name.yml
+++ b/src/test/resources/id_field_name.yml
@@ -1,6 +1,6 @@
 in:
   type: mongodb
-  uri: mongodb://localhost:27017/my_database
+  uri: mongodb://mongo_user:dbpass@localhost:27017/mydb
   collection: "my_collection"
   json_column_name: "json"
   query: '{ rank: { $gte: 3 } }'


### PR DESCRIPTION
This PR is based on #49. So, first 6 commits are unrelated ones.
This PR will solve #50 

Currently, plugin user have to use `uri` option when they want to specify auth mechanism and auth source.
```yaml
in:
  type: mongodb
  uri: mongodb://myuser:mypassword@localhost:27017/my_database?authMechanism=SCRAM-SHA-1&authSource=another_database
```

They can't specify auth source with separated URI parameters, 
To solve this problem, I added 2 new options - `auth_method` and `auth_source`.
Plugin user will be able to set auth method and auth source explicitly.
```yaml
in:
  type: mongodb
  hosts:
  - {host: localhost, port: 27017}
  auth_method: scram-sha-1
  user: myuser
  password: mypassword
  database: my_database
  auth_source: another_database
```

MongoDB supports various kind of auth methods.
https://docs.mongodb.com/manual/core/authentication/
http://mongodb.github.io/mongo-java-driver/3.0/driver-async/reference/connecting/authenticating/

* SCRAM-SHA-1
* MONGODB-CR
* x.509
* Kerberos (GSSAPI)
* LDAP (PLAIN)

However, what I supported were only `scram-sha-1`, `mongodb-cr` and `auto`.
When plugin user choose `auto`,  mongodb-java-client will negotiate the best mechanism based on the version of the server that the client is authenticating to.
If the server version is 3.0 or higher, the driver will authenticate using the SCRAM-SHA-1 mechanism.
Otherwise, the driver will authenticate using the MONGODB_CR mechanism. 
