### PR TITLE
Use OpenJDK instead of OracleJDK to fix Travis CI failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 services:
   - docker


### PR DESCRIPTION
Currently, Travis CI fails during installing Oracle JDK. https://github.com/hakobera/embulk-input-mongodb/pull/53
https://travis-ci.org/hakobera/embulk-input-mongodb/builds/624470253

I faced this problem with many other Embulk plugins, Embulk core as well.
I think using OpenJDK is a practical and reasonable solution.

```
$ ~/bin/install-jdk.sh --target "/home/travis/oraclejdk8" --workspace "/home/travis/.cache/install-jdk" --feature "8" --license "BCL"
Ignoring license option: BCL -- using GPLv2+CE by default
install-jdk.sh 2019-10-16
Expected feature release number in range of 9 to 14, but got: 8
The command "~/bin/install-jdk.sh --target "/home/travis/oraclejdk8" --workspace "/home/travis/.cache/install-jdk" --feature "8" --license "BCL"" failed and exited with 3 during .
```